### PR TITLE
Properly define saltpeter as an oxidizer

### DIFF
--- a/src/main/java/toops/tsteelworks/common/core/TSContent.java
+++ b/src/main/java/toops/tsteelworks/common/core/TSContent.java
@@ -214,6 +214,8 @@ public class TSContent {
 		registry.registerAgent("coal", IMixAgentRegistry.AgentType.OXIDIZER, 43);
 		registry.registerAgent("dustCoal", IMixAgentRegistry.AgentType.OXIDIZER, 37);
 		registry.registerAgent("dyeLime", IMixAgentRegistry.AgentType.OXIDIZER, 37);
+		registry.registerAgent("dustSaltpeter", IMixAgentRegistry.AgentType.OXIDIZER, 30);
+		registry.registerAgent("dustSaltpetre", IMixAgentRegistry.AgentType.OXIDIZER, 30);
 
 		registry.registerAgent("dustRedstone", IMixAgentRegistry.AgentType.REDUCER, 65);
 		registry.registerAgent("dustManganese", IMixAgentRegistry.AgentType.REDUCER, 47);
@@ -222,8 +224,6 @@ public class TSContent {
 		registry.registerAgent("dustAluminium", IMixAgentRegistry.AgentType.REDUCER, 60);
 		registry.registerAgent("dustBone", IMixAgentRegistry.AgentType.REDUCER, 37);
 		registry.registerAgent("oreberryEssence", IMixAgentRegistry.AgentType.REDUCER, 27);
-		registry.registerAgent("dustSaltpeter", IMixAgentRegistry.AgentType.REDUCER, 30);
-		registry.registerAgent("dustSaltpetre", IMixAgentRegistry.AgentType.REDUCER, 30);
 
 		registry.registerAgent("blockSand", IMixAgentRegistry.AgentType.PURIFIER, 100);
 		registry.registerAgent("hambone", IMixAgentRegistry.AgentType.PURIFIER, 73);


### PR DESCRIPTION
Saltpeter is currently defined as a reducer, but its only usage is as an oxidizer in the steel recipe, thus while still being properly consumed, it does not properly shift click into the slot (among possible other things)
